### PR TITLE
fix(reactjs-fun/recompose): add 16 catch done for error timeout

### DIFF
--- a/subjects/reactjs-fun/exercise/recompose.js
+++ b/subjects/reactjs-fun/exercise/recompose.js
@@ -178,7 +178,8 @@ describe('reactjs-fun/recompose', () => {
           expect(div.querySelector('.loaded')).toExist();
           expect(div.querySelectorAll('li').length).toBe(3);
           done();
-        });
+        })
+        .catch(done);
     });
   });
 


### PR DESCRIPTION
Otherwise the test times out without reporting error if an exception is throw in `then`, such as an assertion failure.